### PR TITLE
fix: Add method parameter to VerificationDone

### DIFF
--- a/matrix/verificationCallbacks.go
+++ b/matrix/verificationCallbacks.go
@@ -28,7 +28,7 @@ func (aavc *AcceptAllVerificationCallbacks) VerificationCancelled(ctx context.Co
 }
 
 // VerificationDone is called when the verification is done.
-func (aavc *AcceptAllVerificationCallbacks) VerificationDone(ctx context.Context, txnID id.VerificationTransactionID) {
+func (aavc *AcceptAllVerificationCallbacks) VerificationDone(ctx context.Context, txnID id.VerificationTransactionID, method event.VerificationMethod) {
 	log.Info().Str("txnID", txnID.String()).Msg("Verification done")
 }
 


### PR DESCRIPTION
The new Mautrix version added an additional parameter to the method, add it here as well otherwise connecting to Matrix fails with

panic: callbacks must implement RequiredCallbacks